### PR TITLE
Add Bedrock permissions to VPC group

### DIFF
--- a/infra/service.ts
+++ b/infra/service.ts
@@ -144,6 +144,14 @@ export function createService(
                     ],
                     Resource: appSecrets.arn,
                 },
+                {
+                    Effect: "Allow",
+                    Action: [
+                        "bedrock:InvokeModel",
+                        "bedrock:InvokeModelWithResponseStream"
+                    ],
+                    Resource: "arn:aws:bedrock:*:*:model/meta-llama/*"
+                },
             ],
         },
     });


### PR DESCRIPTION
Per the docs, this should allow the Pontus codebase to directly query any Llama model. We can loosen the condition to any model if desired.